### PR TITLE
Fixed prefill issue for autocomplete field

### DIFF
--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -78,11 +78,11 @@ export function matchCompanyFields(existingOrganizationData) {
       street: existingOrganizationData?.address.street || '',
       city: existingOrganizationData?.address.city || '',
       provinceOrState: existingOrganizationData?.address.province_state || '',
-      country: {
+      'country-label': {
         label: existingOrganizationData?.address.country || '',
         value: existingOrganizationData?.address.country || '',
       },
-      'country-label': existingOrganizationData?.address.country || '',
+      country: existingOrganizationData?.address.country || '',
       postalCode: existingOrganizationData?.address.postal_code || '',
     },
     twitterHandle: existingOrganizationData?.twitter_handle || '',
@@ -179,12 +179,8 @@ export function matchWorkingGroupFields(
           value: item?.working_group_id,
           participation_levels: wg?.participation_levels,
         } || '',
-      participationLevel:
-        {
-          label: item?.participation_level,
-          value: item?.participation_level,
-        } || '',
-      effectiveDate: new Date(item?.effective_date) || '',
+      participationLevel: item?.participation_level || '',
+      effectiveDate: item?.effective_date?.substring(0, 10) || '',
       workingGroupRepresentative: {
         firstName: item?.contact.first_name || '',
         lastName: item?.contact.last_name || '',

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import MembershipContext from '../../../Context/MembershipContext';
 import {
   matchCompanyFields,
@@ -87,7 +87,6 @@ const CompanyInformation = ({ formik }) => {
             // Call the the function to map the retrived
             // organization backend data to fit frontend
             let tempOrg = matchCompanyFields(organizations[0]);
-            console.log(tempOrg);
             // Call the setFieldValue of Formik, to set
             // organization field with the mapped data,
             // if nested, it will automatically map the

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationCompany.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationCompany.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import Input from '../../UIComponents/Inputs/Input';
 import { formField } from '../../UIComponents/FormComponents/formFieldModel';
 import Autocomplete from '@material-ui/lab/Autocomplete';

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import Input from '../../UIComponents/Inputs/Input';
 import { formField } from '../../UIComponents/FormComponents/formFieldModel';
 import { Checkbox, FormControlLabel } from '@material-ui/core';

--- a/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
+++ b/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import MembershipLevelFeeTable from './MembershipLevelFeeTable';
 import MembershipContext from '../../../Context/MembershipContext';
 import Loading from '../../UIComponents/Loading/Loading';
@@ -48,7 +48,7 @@ const MembershipLevel = ({ formik }) => {
     // use fake json data; if running with API, use API
 
     // just for React only testing.
-    let currentFormId = 'form_1';
+    // let currentFormId = 'form_1';
     let url_prefix_local;
     let url_suffix_local = '';
     if (getCurrentMode() === MODE_REACT_ONLY) {

--- a/src/main/www/src/components/Pages/MembershipLevel/MembershipLevelFeeTable.js
+++ b/src/main/www/src/components/Pages/MembershipLevel/MembershipLevelFeeTable.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 /**
  * This is a pure static html table copied from membership site:
  * https://www.eclipse.org/membership/#tab-fees

--- a/src/main/www/src/components/Pages/Review/Review.js
+++ b/src/main/www/src/components/Pages/Review/Review.js
@@ -161,7 +161,7 @@ const Review = ({ values, submitForm }) => {
             <div className="row margin-bottom-30">
               <div className="col-md-8">
                 <label>Working group</label>
-                <div className="preview-field">{el.workingGroup}</div>
+                <div className="preview-field">{el['workingGroup-label']}</div>
               </div>
               <div className="col-md-8">
                 <label>Intended Participation Level</label>

--- a/src/main/www/src/components/Pages/SignIn/SignInIntroduction.js
+++ b/src/main/www/src/components/Pages/SignIn/SignInIntroduction.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const SignInIntroduction = () => {
   return (
     <div className="row">

--- a/src/main/www/src/components/Pages/SigningAuthority/SigningAuthority.js
+++ b/src/main/www/src/components/Pages/SigningAuthority/SigningAuthority.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import CustomStepButton from '../../UIComponents/Button/CustomStepButton';
 import Input from '../../UIComponents/Inputs/Input';
 import { formField } from '../../UIComponents/FormComponents/formFieldModel';
@@ -11,7 +10,6 @@ import { formField } from '../../UIComponents/FormComponents/formFieldModel';
 const sectionName = 'signing-authority';
 const SigningAuthority = ({ formik }) => {
   const { signingAuthorityRepresentative } = formField;
-  console.log(formik.values);
   return (
     <form onSubmit={formik.handleSubmit}>
       <h1 className="fw-600 h2" id={sectionName}>

--- a/src/main/www/src/components/Pages/SubmitSuccess/SubmitSuccess.js
+++ b/src/main/www/src/components/Pages/SubmitSuccess/SubmitSuccess.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 /**
  * This is just a pure html component to
  * display after all steps finished and

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupEffectiveDate.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupEffectiveDate.js
@@ -1,11 +1,10 @@
-import React from 'react';
 import DateInput from '../../UIComponents/Inputs/DateInput';
 
 /**
  * Render Effective Date input component (react-datepicker)
  *
  *  - Props:
- *    - name: fieldName (for Effective Date, an example would be: `workingGroups[i].effectiveDate`); 
+ *    - name: fieldName (for Effective Date, an example would be: `workingGroups[i].effectiveDate`);
  *            this is handled by and passed from WorkingGroup component
  */
 const EffectiveDate = ({ name, index, formik }) => {

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupParticipationLevel.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupParticipationLevel.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import { makeStyles, TextField } from '@material-ui/core';
 
@@ -21,30 +21,28 @@ const useStyles = makeStyles(() => ({
 
 const ParticipationLevel = ({
   name,
-  workingGroup,
-  workingGroupListData,
+  workingGroupUserJoined,
+  fullWorkingGroupList,
   formik,
   index,
 }) => {
   const classes = useStyles();
+  const [participationLevelOptions, setParticipationLevelOptions] = useState(
+    []
+  );
 
-  const [participationLevels, setParticipationLevels] = useState([]);
   const theIndex = index;
   useEffect(() => {
     // If have selected working group, find this working group's
     // participation levels, and pass to the react-select option
-    if (workingGroupListData) {
-      let temp = workingGroupListData?.find(
-        (item) => workingGroup === item.value
+    if (fullWorkingGroupList) {
+      let temp = fullWorkingGroupList?.find(
+        (item) => workingGroupUserJoined.value === item.value
       );
-      setParticipationLevels(temp?.participation_levels);
-      formik.setFieldValue(
-        `workingGroups.${theIndex}.participationLevel-label`,
-        ''
-      );
+      setParticipationLevelOptions(temp?.participation_levels);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workingGroupListData]);
+  }, [workingGroupUserJoined]);
 
   return (
     <>
@@ -55,21 +53,15 @@ const ParticipationLevel = ({
       <div className="row">
         <div className="col-md-12">
           <Autocomplete
-            options={participationLevels}
+            options={participationLevelOptions}
             getOptionLabel={(option) => (option ? option : '')}
             fullWidth={true}
             onChange={(ev, value) => {
-              // this is only for display
-              formik.setFieldValue(`${name}-label`, value ? value : null);
-
-              // this is the data will be actually used
               formik.setFieldValue(name, value ? value : null);
             }}
             value={
-              formik.values.workingGroups[theIndex]['participationLevel-label']
-                ? formik.values.workingGroups[theIndex][
-                    'participationLevel-label'
-                  ]
+              formik.values.workingGroups[theIndex]['participationLevel']
+                ? formik.values.workingGroups[theIndex]['participationLevel']
                 : null
             }
             renderInput={(params) => {

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupRepresentative.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupRepresentative.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import Input from '../../UIComponents/Inputs/Input';
 import { formField } from '../../UIComponents/FormComponents/formFieldModel';
 
@@ -35,17 +34,17 @@ const WorkingGroupRepresentative = ({ name, index, formik }) => {
               }
               error={
                 formik.touched.workingGroups?.[theIndex]
-                  .workingGroupRepresentative[`${el.name}`] &&
+                  ?.workingGroupRepresentative?.[`${el.name}`] &&
                 Boolean(
                   formik.errors.workingGroups?.[theIndex]
-                    .workingGroupRepresentative[`${el.name}`]
+                    ?.workingGroupRepresentative?.[`${el.name}`]
                 )
               }
               helperText={
                 formik.touched.workingGroups?.[theIndex]
-                  .workingGroupRepresentative[`${el.name}`] &&
+                  ?.workingGroupRepresentative?.[`${el.name}`] &&
                 formik.errors.workingGroups?.[theIndex]
-                  .workingGroupRepresentative[`${el.name}`]
+                  ?.workingGroupRepresentative?.[`${el.name}`]
               }
             />
           </div>

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -33,7 +33,7 @@ import { FormikProvider } from 'formik';
 
 const WorkingGroupsWrapper = ({ formik }) => {
   const { currentFormId } = useContext(MembershipContext);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [workingGroupsUserJoined, setWorkingGroupsUserJoined] = useState([]);
   const [fullWorkingGroupList, setFullWorkingGroupList] = useState([]);
 


### PR DESCRIPTION
Related to [issue37](https://github.com/EclipseFdn/react-eclipsefdn-members/issues/37), as we need to be able to prefill all fields when user decides to start with an existing form

Changes: 

- Modified some data structure and related function to make the prefill work.
- Removed some unused import. (Mainly are import React)

Tested with API call. Previous prefill issue for working groups step was fixed.
I added the value via MySQL Workbench.

Notice:
As we don't have an API call to get all available working groups, so for now when doing the test, the participationLevel need to match this format: 
[workingGroupID]_level_a
such as "jakarta_ee_level_a"