### PR TITLE
Made formchooser work

### DIFF
--- a/src/main/www/src/App.js
+++ b/src/main/www/src/App.js
@@ -39,10 +39,7 @@ const App = () => {
         <AppHeader />
         <MembershipContext.Provider value={membershipContextValue}>
           <Router>
-            <Main
-              furthestPage={furthestPage}
-              setFurthestPage={setFurthestPage}
-            />
+            <Main />
           </Router>
         </MembershipContext.Provider>
         <AppFooter />

--- a/src/main/www/src/Constants/Constants.js
+++ b/src/main/www/src/Constants/Constants.js
@@ -29,12 +29,12 @@ export const FETCH_HEADER = {
 };
 
 export const membership_levels = [
-  { label: 'Strategic Member', value: 'strategic' },
+  { label: 'Strategic Member', value: 'Strategic Member' },
   {
     label: 'Contributing Member (formerly referred to as Solutions Members)',
-    value: 'contributing',
+    value: 'Contributing Member',
   },
-  { label: 'Associate Member', value: 'associate' },
+  { label: 'Associate Member', value: 'Associate Member' },
 ];
 
 export const PAGE_STEP = [

--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -303,18 +303,13 @@ export function matchWGFieldsToBackend(eachWorkingGroupData, formId) {
  * @param formId - Form Id fetched from the server, sotored in membership context, used for calling APIs
  * @param userId - User Id fetched from the server when sign in, sotored in membership context, used for calling APIs
  */
-export async function executeSendDataByStep(
-  step,
-  formData,
-  formId,
-  userId,
-) {
+export async function executeSendDataByStep(step, formData, formId, userId) {
   switch (step) {
     case 1:
       sendData(
         formId,
         end_point.organizations,
-        matchCompanyFieldsToBackend(formData.organization, formId),
+        matchCompanyFieldsToBackend(formData.organization, formId)
       );
       sendData(
         formId,
@@ -323,7 +318,7 @@ export async function executeSendDataByStep(
           formData.representative.company,
           contact_type.COMPANY,
           formId
-        ),
+        )
       );
       sendData(
         formId,
@@ -332,7 +327,7 @@ export async function executeSendDataByStep(
           formData.representative.marketing,
           contact_type.MARKETING,
           formId
-        ),
+        )
       );
       sendData(
         formId,
@@ -341,7 +336,7 @@ export async function executeSendDataByStep(
           formData.representative.accounting,
           contact_type.ACCOUNTING,
           formId
-        ),
+        )
       );
       break;
 
@@ -353,7 +348,7 @@ export async function executeSendDataByStep(
           formData.membershipLevel,
           formId,
           userId
-        ),
+        )
       );
       break;
 
@@ -362,7 +357,7 @@ export async function executeSendDataByStep(
         sendData(
           formId,
           end_point.working_groups,
-          matchWGFieldsToBackend(item, formId),
+          matchWGFieldsToBackend(item, formId)
         );
       });
       break;

--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -504,12 +504,7 @@ export function deleteData(formId, endpoint, entityId, callback, index) {
  * - Store the returned new form Id in my FormId Context
  * - Send the API calls to organizations and contacts
  * **/
-export async function handleNewForm(
-  setCurrentFormId,
-  formData,
-  userId,
-  defaultBehaviour
-) {
+export async function handleNewForm(setCurrentFormId, defaultBehaviour) {
   if (getCurrentMode() === MODE_REACT_ONLY) {
     defaultBehaviour();
   }
@@ -527,8 +522,8 @@ export async function handleNewForm(
     })
       .then((res) => res.json())
       .then((data) => {
+        console.log('Start with a new one:', data);
         setCurrentFormId(data[0]?.id);
-        executeSendDataByStep(0, formData, data[0]?.id, userId);
         defaultBehaviour();
       });
   }

--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -240,7 +240,7 @@ export function matchMembershipLevelFieldsToBackend(
   return {
     id: formId,
     user_id: userId,
-    membership_level: membershipLevel.value,
+    membership_level: membershipLevel,
     signing_authority: true,
   };
 }
@@ -441,6 +441,15 @@ export function sendData(formId, endpoint, dataBody, fetchMethod) {
   console.log('dataBody: ', dataBody);
   switch (endpoint) {
     case end_point.organizations:
+      if (fetchMethod === FETCH_METHOD.POST) {
+        delete dataBody.id;
+        callSendData(formId, endpoint, FETCH_METHOD.POST, dataBody);
+      } else {
+        callSendData(formId, endpoint, FETCH_METHOD.PUT, dataBody, dataBody.id);
+      }
+      break;
+
+    case '':
       if (fetchMethod === FETCH_METHOD.POST) {
         delete dataBody.id;
         callSendData(formId, endpoint, FETCH_METHOD.POST, dataBody);

--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -306,12 +306,12 @@ export function matchWGFieldsToBackend(eachWorkingGroupData, formId) {
 export async function executeSendDataByStep(step, formData, formId, userId) {
   switch (step) {
     case 1:
-      sendData(
+      callSendData(
         formId,
         end_point.organizations,
         matchCompanyFieldsToBackend(formData.organization, formId)
       );
-      sendData(
+      callSendData(
         formId,
         end_point.contacts,
         matchContactFieldsToBackend(
@@ -320,7 +320,7 @@ export async function executeSendDataByStep(step, formData, formId, userId) {
           formId
         )
       );
-      sendData(
+      callSendData(
         formId,
         end_point.contacts,
         matchContactFieldsToBackend(
@@ -329,7 +329,7 @@ export async function executeSendDataByStep(step, formData, formId, userId) {
           formId
         )
       );
-      sendData(
+      callSendData(
         formId,
         end_point.contacts,
         matchContactFieldsToBackend(
@@ -341,7 +341,7 @@ export async function executeSendDataByStep(step, formData, formId, userId) {
       break;
 
     case 2:
-      sendData(
+      callSendData(
         formId,
         '',
         matchMembershipLevelFieldsToBackend(
@@ -354,7 +354,7 @@ export async function executeSendDataByStep(step, formData, formId, userId) {
 
     case 3:
       formData.workingGroups.forEach((item) => {
-        sendData(
+        callSendData(
           formId,
           end_point.working_groups,
           matchWGFieldsToBackend(item, formId)
@@ -374,13 +374,14 @@ export async function executeSendDataByStep(step, formData, formId, userId) {
  * @param formId - Form Id fetched from the server, sotored in membership context, used for calling APIs
  * @param endpoint - To which endpoint the fetch is calling to backend:
  * /form/{id}, /form/{id}/organizations/{id}, /form/{id}/contacts/{id}, /form/{id}/working_groups/{id}
- * @param method - Fetch methods: POST, GET, PUT, DELETE
  * @param dataBody - The data body passed to server, normally is the filled form data to be saved
- * @param entityId - The Id of organizations, or contacts, or working groups entry;
  * If empty, is creating a new entity, use POST method;
  * If has value, is fetched from server, use PUT or DELETE;
  */
-function callSendData(formId, endpoint = '', method, dataBody, entityId = '') {
+function callSendData(formId, endpoint = '', dataBody) {
+  const entityId = dataBody.id ? dataBody.id : '';
+  const method = dataBody.id ? FETCH_METHOD.PUT : FETCH_METHOD.POST;
+
   let url = api_prefix_form + `/${formId}`;
 
   if (endpoint) {
@@ -406,54 +407,6 @@ function callSendData(formId, endpoint = '', method, dataBody, entityId = '') {
     }).then((res) => {
       console.log(res.status);
     });
-  }
-}
-
-/**
- * PUT or POST function
- *
- * @param formId -
- * Form Id fetched from the server, sotored in membership context, used for calling APIs
- * @param endpoint -
- * To which endpoint the fetch is calling to backend:
- * /form/{id}, /form/{id}/organizations/{id}, /form/{id}/contacts/{id}, /form/{id}/working_groups/{id}
- * @param dataBody -
- * The data body passed to server, normally is the filled form data to be saved
- *
- * If no data.id, means it's a new data entry, we should use POST. otherwise, use PUT
- */
-export function sendData(formId, endpoint, dataBody) {
-  switch (endpoint) {
-    case end_point.organizations:
-      if (!dataBody.id) {
-        callSendData(formId, endpoint, FETCH_METHOD.POST, dataBody);
-      } else {
-        callSendData(formId, endpoint, FETCH_METHOD.PUT, dataBody, dataBody.id);
-      }
-      break;
-
-    case '':
-      if (!dataBody.id) {
-        callSendData(formId, endpoint, FETCH_METHOD.POST, dataBody);
-      } else {
-        callSendData(formId, endpoint, FETCH_METHOD.PUT, dataBody, dataBody.id);
-      }
-      break;
-
-    case end_point.working_groups:
-      if (!dataBody.id) {
-        callSendData(formId, endpoint, FETCH_METHOD.POST, dataBody);
-      } else {
-        callSendData(formId, endpoint, FETCH_METHOD.PUT, dataBody, dataBody.id);
-      }
-      break;
-
-    default:
-      if (!dataBody.id) {
-        callSendData(formId, endpoint, FETCH_METHOD.POST, dataBody);
-      } else {
-        callSendData(formId, endpoint, FETCH_METHOD.PUT, dataBody, dataBody.id);
-      }
   }
 }
 

--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -423,8 +423,6 @@ function callSendData(formId, endpoint = '', method, dataBody, entityId = '') {
  * If no data.id, means it's a new data entry, we should use POST. otherwise, use PUT
  */
 export function sendData(formId, endpoint, dataBody) {
-  console.log('endpoint: ', endpoint);
-  console.log('dataBody: ', dataBody);
   switch (endpoint) {
     case end_point.organizations:
       if (!dataBody.id) {
@@ -535,7 +533,7 @@ export async function handleNewForm(setCurrentFormId, defaultBehaviour) {
     })
       .then((res) => res.json())
       .then((data) => {
-        console.log('Start with a new one:', data);
+        console.log('Start with a new form:', data);
         setCurrentFormId(data[0]?.id);
         defaultBehaviour();
       })

--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -547,7 +547,8 @@ export async function handleNewForm(setCurrentFormId, defaultBehaviour) {
         console.log('Start with a new one:', data);
         setCurrentFormId(data[0]?.id);
         defaultBehaviour();
-      });
+      })
+      .catch((err) => console.log(err));
   }
 
   // Probably Also need to delete the old form Id, or keep in the db for 30 days

--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -77,11 +77,11 @@ export function matchCompanyFields(existingOrganizationData) {
       street: existingOrganizationData?.address.street || '',
       city: existingOrganizationData?.address.city || '',
       provinceOrState: existingOrganizationData?.address.province_state || '',
-      country: {
+      country: existingOrganizationData?.address.country || '',
+      'country-label': {
         label: existingOrganizationData?.address.country || '',
         value: existingOrganizationData?.address.country || '',
       },
-      'country-label': existingOrganizationData?.address.country || '',
       postalCode: existingOrganizationData?.address.postal_code || '',
     },
     twitterHandle: existingOrganizationData?.twitter_handle || '',

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
@@ -113,7 +113,6 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
   // as long as currentFormId and setFieldValue
   // Function does not change, will not cause re-render again
   useEffect(() => {
-    console.log(furthestPage.index);
     setLoading(true);
     if (isStartNewForm) {
       if (furthestPage.index > 1 && !formik.values.organizations.id) {

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
@@ -120,10 +120,12 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
         // so, we need to GET the info user submitted and if user changes anything,
         // we will use the organization_id from the GET to do the PUT to update the info.
         setLoading(false);
-      } else { // This means this is the 1st time the user see this page, no need to do any API call.
+      } else {
+        // This means this is the 1st time the user see this page, no need to do any API call.
         setLoading(false);
       }
-    } else { // continue with an existing one
+    } else {
+      // continue with an existing one
       detectModeAndFetch();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
@@ -112,7 +112,6 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
   // as long as currentFormId and setFieldValue
   // Function does not change, will not cause re-render again
   useEffect(() => {
-    setLoading(true);
     if (isStartNewForm) {
       if (furthestPage.index > 1 && !formik.values.organizations.id) {
         // This means user already submitted/finished this page, and comes back from a further page/step
@@ -120,7 +119,9 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
         // we will use the organization_id from the GET to do the PUT to update the info.
         setLoading(false);
       } else {
-        // This means this is the 1st time the user see this page, no need to do any API call.
+        // This means this is the 1st time the user see this page,
+        // or the user already got the organizations.id
+        // no need to do any API call
         setLoading(false);
       }
     } else {

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
@@ -48,7 +48,7 @@ const Contacts = ({ formik }) => {
       formik.setFieldValue('representative.marketing', newValues);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMarketingSameAsCompany]);
+  }, [isMarketingSameAsCompany, formik.values.representative.company]);
 
   // update representative.accounting values based on related checkbox
   useEffect(() => {
@@ -61,7 +61,7 @@ const Contacts = ({ formik }) => {
       formik.setFieldValue('representative.accounting', newValues);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAccountingSameAsCompany]);
+  }, [isAccountingSameAsCompany, formik.values.representative.company]);
 
   const generateContacts = (
     representativeFields,

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -133,6 +133,7 @@ export default function Main({ furthestPage, setFurthestPage }) {
               formField={formField}
               label={COMPANY_INFORMATION}
               setFurthestPage={setFurthestPage}
+              history={history}
             />
           </Route>
 

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -5,7 +5,6 @@ import SignIn from './SignIn/SignIn';
 import {
   COMPANY_INFORMATION,
   SIGNING_AUTHORITY,
-  WORKING_GROUPS,
   PAGE_STEP,
 } from '../../Constants/Constants';
 import {
@@ -82,6 +81,7 @@ export default function Main() {
       // update the membershipLevel values
       const membershipLevel = values.membershipLevel;
       setUpdatedFormValues({ ...updatedFormValues, membershipLevel });
+      console.log('updated membership level: ', values);
 
       // fetch method for submitting membership level will always be PUT
       // because we have to create one first to get the form_id
@@ -105,6 +105,17 @@ export default function Main() {
       // update the workingGroups values
       const workingGroups = values.workingGroups;
       setUpdatedFormValues({ ...updatedFormValues, workingGroups });
+      console.log('updated working groups: ', values);
+
+      const fetchMethod = furthestPage.index > 3 ? 'PUT' : 'POST';
+      executeSendDataByStep(
+        3,
+        values,
+        currentFormId,
+        currentUser.name,
+        fetchMethod
+      );
+
       goToNextStep(3, '/signing-authority');
     },
   });
@@ -198,9 +209,8 @@ export default function Main() {
           <Route path="/working-groups">
             {furthestPage.index >= 3 ? (
               <WorkingGroupsWrapper
-                formField={formField}
-                label={WORKING_GROUPS}
                 formik={formikWorkingGroups}
+                isStartNewForm={isStartNewForm}
               />
             ) : (
               <Redirect to={furthestPage.pathName} />

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -174,6 +174,7 @@ export default function Main() {
               <MembershipLevel
                 formik={formikMembershipLevel}
                 isStartNewForm={isStartNewForm}
+                furthestPage={furthestPage}
               />
             ) : (
               <Redirect to={furthestPage.pathName} />
@@ -185,6 +186,7 @@ export default function Main() {
               <WorkingGroupsWrapper
                 formik={formikWorkingGroups}
                 isStartNewForm={isStartNewForm}
+                furthestPage={furthestPage}
               />
             ) : (
               <Redirect to={furthestPage.pathName} />
@@ -193,11 +195,7 @@ export default function Main() {
 
           <Route path="/signing-authority">
             {furthestPage.index >= 4 ? (
-              <SigningAuthority
-                formField={formField}
-                label={SIGNING_AUTHORITY}
-                formik={formikSigningAuthority}
-              />
+              <SigningAuthority formik={formikSigningAuthority} />
             ) : (
               <Redirect to={furthestPage.pathName} />
             )}

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -58,21 +58,7 @@ export default function Main() {
       });
       console.log('updated company info: ', values);
 
-      // check if the furthest page index is greater than current page index
-      // if so, means user comes back from a further page so we need do PUT
-      // if not, means this is the first time the user submits the info, we need do PUT
-      let fetchMethod = 'PUT';
-      if (isStartNewForm) {
-        fetchMethod = furthestPage.index > 1 ? 'PUT' : 'POST';
-      }
-
-      executeSendDataByStep(
-        1,
-        values,
-        currentFormId,
-        currentUser.name,
-        fetchMethod
-      );
+      executeSendDataByStep(1, values, currentFormId, currentUser.name);
 
       goToNextStep(1, '/membership-level');
     },
@@ -87,16 +73,7 @@ export default function Main() {
       setUpdatedFormValues({ ...updatedFormValues, membershipLevel });
       console.log('updated membership level: ', values);
 
-      // fetch method for submitting membership level will always be PUT
-      // because we have to create one first to get the form_id
-      const fetchMethod = 'PUT';
-      executeSendDataByStep(
-        2,
-        values,
-        currentFormId,
-        currentUser.name,
-        fetchMethod
-      );
+      executeSendDataByStep(2, values, currentFormId, currentUser.name);
 
       goToNextStep(2, '/working-groups');
     },
@@ -111,14 +88,7 @@ export default function Main() {
       setUpdatedFormValues({ ...updatedFormValues, workingGroups });
       console.log('updated working groups: ', values);
 
-      const fetchMethod = furthestPage.index > 3 ? 'PUT' : 'POST';
-      executeSendDataByStep(
-        3,
-        values,
-        currentFormId,
-        currentUser.name,
-        fetchMethod
-      );
+      executeSendDataByStep(3, values, currentFormId, currentUser.name);
 
       goToNextStep(3, '/signing-authority');
     },

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -4,7 +4,6 @@ import { useFormik } from 'formik';
 import SignIn from './SignIn/SignIn';
 import {
   COMPANY_INFORMATION,
-  MEMBERSHIP_LEVEL,
   SIGNING_AUTHORITY,
   WORKING_GROUPS,
   PAGE_STEP,
@@ -83,6 +82,18 @@ export default function Main() {
       // update the membershipLevel values
       const membershipLevel = values.membershipLevel;
       setUpdatedFormValues({ ...updatedFormValues, membershipLevel });
+
+      // fetch method for submitting membership level will always be PUT
+      // because we have to create one first to get the form_id
+      const fetchMethod = 'PUT';
+      executeSendDataByStep(
+        2,
+        values,
+        currentFormId,
+        currentUser.name,
+        fetchMethod
+      );
+
       goToNextStep(2, '/working-groups');
     },
   });
@@ -177,7 +188,7 @@ export default function Main() {
             {furthestPage.index >= 2 ? (
               <MembershipLevel
                 formik={formikMembershipLevel}
-                label={MEMBERSHIP_LEVEL}
+                isStartNewForm={isStartNewForm}
               />
             ) : (
               <Redirect to={furthestPage.pathName} />

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -4,7 +4,6 @@ import { useFormik } from 'formik';
 import SignIn from './SignIn/SignIn';
 import {
   COMPANY_INFORMATION,
-  SIGNING_AUTHORITY,
   PAGE_STEP,
 } from '../../Constants/Constants';
 import {

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -61,7 +61,11 @@ export default function Main() {
       // check if the furthest page index is greater than current page index
       // if so, means user comes back from a further page so we need do PUT
       // if not, means this is the first time the user submits the info, we need do PUT
-      const fetchMethod = furthestPage.index > 1 ? 'PUT' : 'POST';
+      let fetchMethod = 'PUT';
+      if (isStartNewForm) {
+        fetchMethod = furthestPage.index > 1 ? 'PUT' : 'POST';
+      }
+
       executeSendDataByStep(
         1,
         values,

--- a/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
+++ b/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
@@ -49,7 +49,6 @@ const MembershipLevel = ({ formik, isStartNewForm }) => {
 
     // just for React only testing.
     // let currentFormId = 'form_1';
-
     const detectModeAndFetch = () => {
       let url_prefix_local;
       let url_suffix_local = '';
@@ -96,9 +95,12 @@ const MembershipLevel = ({ formik, isStartNewForm }) => {
 
     if (isStartNewForm) {
       setLoading(false);
-    } else {
-      // continue with an existing one
+    } else if (formik.values.membershipLevel === '') {
+      // continue with an existing one, if the value is empty
+      // it means this is the first time the user see this page, need to do GET API call
       detectModeAndFetch();
+    } else {
+      setLoading(false);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
+++ b/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
@@ -33,7 +33,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const MembershipLevel = ({ formik }) => {
+const MembershipLevel = ({ formik, isStartNewForm }) => {
   const { currentFormId } = useContext(MembershipContext);
   const { membershipLevel } = formField;
   const classes = useStyles();
@@ -48,42 +48,61 @@ const MembershipLevel = ({ formik }) => {
     // use fake json data; if running with API, use API
 
     // just for React only testing.
-    let currentFormId = 'form_1';
-    let url_prefix_local;
-    let url_suffix_local = '';
-    if (getCurrentMode() === MODE_REACT_ONLY) {
-      url_prefix_local = 'membership_data';
-      url_suffix_local = '/form.json';
-    }
+    // let currentFormId = 'form_1';
 
-    if (getCurrentMode() === MODE_REACT_API) {
-      url_prefix_local = api_prefix_form;
-    }
+    setLoading(true);
 
-    // If the current form exsits, and it is not creating a new form
-    if (currentFormId && currentFormId !== newForm_tempId) {
-      fetch(url_prefix_local + `/${currentFormId}` + url_suffix_local, {
-        headers: FETCH_HEADER,
-      })
-        .then((resp) => resp.json())
-        .then((data) => {
-          if (data) {
-            // mapMembershipLevel(): Call the the function to map
-            // the retrived membership level backend data to fit frontend, and
-            // setFieldValue(): Prefill Data --> Call the setFieldValue of
-            // Formik, to set membershipLevel field with the mapped data
-            const tempMembershipLevel = mapMembershipLevel(
-              data[0]?.membership_level,
-              membership_levels
-            );
-            formik.setFieldValue('membershipLevel', tempMembershipLevel.label);
-            formik.setFieldValue('membershipLevel-label', tempMembershipLevel);
-          }
-          setLoading(false);
-        });
-    } else {
+    const detectModeAndFetch = () => {
+      let url_prefix_local;
+      let url_suffix_local = '';
+      if (getCurrentMode() === MODE_REACT_ONLY) {
+        url_prefix_local = 'membership_data';
+        url_suffix_local = '/form.json';
+      }
+
+      if (getCurrentMode() === MODE_REACT_API) {
+        url_prefix_local = api_prefix_form;
+      }
+
+      // If the current form exsits, and it is not creating a new form
+      if (currentFormId && currentFormId !== newForm_tempId) {
+        fetch(url_prefix_local + `/${currentFormId}` + url_suffix_local, {
+          headers: FETCH_HEADER,
+        })
+          .then((resp) => resp.json())
+          .then((data) => {
+            if (data) {
+              // mapMembershipLevel(): Call the the function to map
+              // the retrived membership level backend data to fit frontend, and
+              // setFieldValue(): Prefill Data --> Call the setFieldValue of
+              // Formik, to set membershipLevel field with the mapped data
+              const tempMembershipLevel = mapMembershipLevel(
+                data[0]?.membership_level,
+                membership_levels
+              );
+              formik.setFieldValue(
+                'membershipLevel',
+                tempMembershipLevel.label
+              );
+              formik.setFieldValue(
+                'membershipLevel-label',
+                tempMembershipLevel
+              );
+            }
+            setLoading(false);
+          });
+      } else {
+        setLoading(false);
+      }
+    };
+
+    if (isStartNewForm) {
       setLoading(false);
+    } else {
+      // continue with an existing one
+      detectModeAndFetch();
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentFormId]);
 

--- a/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
+++ b/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
@@ -80,7 +80,7 @@ const MembershipLevel = ({ formik, isStartNewForm }) => {
               );
               formik.setFieldValue(
                 'membershipLevel',
-                tempMembershipLevel.label
+                tempMembershipLevel.value
               );
               formik.setFieldValue(
                 'membershipLevel-label',

--- a/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
+++ b/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
@@ -50,8 +50,6 @@ const MembershipLevel = ({ formik, isStartNewForm }) => {
     // just for React only testing.
     // let currentFormId = 'form_1';
 
-    setLoading(true);
-
     const detectModeAndFetch = () => {
       let url_prefix_local;
       let url_suffix_local = '';
@@ -127,6 +125,9 @@ const MembershipLevel = ({ formik, isStartNewForm }) => {
               options={membership_levels}
               fullWidth={true}
               getOptionLabel={(option) => (option?.label ? option.label : '')}
+              getOptionSelected={(option, value) =>
+                option.value === value.value
+              }
               onChange={(ev, value) => {
                 // this is only for display
                 formik.setFieldValue(

--- a/src/main/www/src/components/Pages/Review/Review.js
+++ b/src/main/www/src/components/Pages/Review/Review.js
@@ -161,7 +161,9 @@ const Review = ({ values, submitForm }) => {
             <div className="row margin-bottom-30">
               <div className="col-md-8">
                 <label>Working group</label>
-                <div className="preview-field">{el['workingGroup-label']}</div>
+                <div className="preview-field">
+                  {el['workingGroup']['label']}
+                </div>
               </div>
               <div className="col-md-8">
                 <label>Intended Participation Level</label>

--- a/src/main/www/src/components/Pages/SignIn/SignIn.js
+++ b/src/main/www/src/components/Pages/SignIn/SignIn.js
@@ -84,17 +84,16 @@ class SignIn extends React.Component {
 
   render() {
     return (
-      <MembershipContext.Consumer>
-        {({ setFurthestPage }) => (
-          <>
-            {this.context.currentUser ? (
-              <FormChooser setFurthestPage={setFurthestPage} />
-            ) : (
-              this.renderButtons(setFurthestPage)
-            )}
-          </>
+      <>
+        {this.context.currentUser ? (
+          <FormChooser
+            setFurthestPage={this.props.setFurthestPage}
+            history={this.props.history}
+          />
+        ) : (
+          this.renderButtons(this.props.setFurthestPage)
         )}
-      </MembershipContext.Consumer>
+      </>
     );
   }
 }

--- a/src/main/www/src/components/Pages/SignIn/SignIn.js
+++ b/src/main/www/src/components/Pages/SignIn/SignIn.js
@@ -10,6 +10,7 @@ import {
   MODE_REACT_API,
 } from '../../../Constants/Constants';
 import { NavLink } from 'react-router-dom';
+import Loading from '../../UIComponents/Loading/Loading';
 
 /**
  * - When it is only running React App without server, uses fake user in public/fake_user.json
@@ -36,6 +37,9 @@ import { NavLink } from 'react-router-dom';
  */
 class SignIn extends React.Component {
   static contextType = MembershipContext;
+  state = {
+    needLoading: true,
+  };
   getFakeUser = (setFurthestPage) => {
     setFurthestPage({ index: 1, pathName: '/company-info' });
     fetch('membership_data/fake_user.json', { headers: FETCH_HEADER })
@@ -45,30 +49,37 @@ class SignIn extends React.Component {
       });
   };
 
-  renderButtons = (setFurthestPage) => (
-    <div className="text-center margin-bottom-20">
-      {getCurrentMode() === MODE_REACT_ONLY && (
-        <NavLink to="/company-info">
-          <button
-            type="button"
-            onClick={() => this.getFakeUser(setFurthestPage)}
-            className="btn btn-secondary"
-          >
-            React Only Login
-          </button>
-        </NavLink>
-      )}
+  renderButtons = (setFurthestPage) =>
+    this.state.needLoading ? (
+      <Loading />
+    ) : (
+      <div className="text-center margin-bottom-20">
+        {getCurrentMode() === MODE_REACT_ONLY && (
+          <NavLink to="/company-info">
+            <button
+              type="button"
+              onClick={() => this.getFakeUser(setFurthestPage)}
+              className="btn btn-secondary"
+            >
+              React Only Login
+            </button>
+          </NavLink>
+        )}
 
-      {getCurrentMode() === MODE_REACT_API && (
-        <a href="/login" className="btn btn-secondary">
-          Sign In
+        {getCurrentMode() === MODE_REACT_API && (
+          <a
+            href="/login"
+            className="btn btn-secondary"
+            onClick={() => this.setState({ needLoading: true })}
+          >
+            Sign In
+          </a>
+        )}
+        <a href="https://accounts.eclipse.org/" className="btn btn-secondary">
+          Create an account
         </a>
-      )}
-      <a href="https://accounts.eclipse.org/" className="btn btn-secondary">
-        Create an account
-      </a>
-    </div>
-  );
+      </div>
+    );
 
   componentDidMount() {
     if (getCurrentMode() === MODE_REACT_API) {
@@ -77,8 +88,12 @@ class SignIn extends React.Component {
         .then((data) => {
           console.log('data: ', data); // {family_name: "User1", given_name: "User1", name: "user1"}
           this.context.setCurrentUser(data);
+          this.setState({ needLoading: false });
         })
-        .catch((err) => console.log(err));
+        .catch((err) => {
+          console.log(err);
+          this.setState({ needLoading: false });
+        });
     }
   }
 
@@ -89,6 +104,7 @@ class SignIn extends React.Component {
           <FormChooser
             setFurthestPage={this.props.setFurthestPage}
             history={this.props.history}
+            setIsStartNewForm={this.props.setIsStartNewForm}
           />
         ) : (
           this.renderButtons(this.props.setFurthestPage)

--- a/src/main/www/src/components/Pages/SignIn/SignIn.js
+++ b/src/main/www/src/components/Pages/SignIn/SignIn.js
@@ -94,6 +94,8 @@ class SignIn extends React.Component {
           console.log(err);
           this.setState({ needLoading: false });
         });
+    } else {
+      this.setState({ needLoading: false });
     }
   }
 

--- a/src/main/www/src/components/Pages/SignIn/SignIn.js
+++ b/src/main/www/src/components/Pages/SignIn/SignIn.js
@@ -86,7 +86,7 @@ class SignIn extends React.Component {
       fetch(api_prefix() + `/${end_point.userinfo}`, { headers: FETCH_HEADER })
         .then((res) => res.json())
         .then((data) => {
-          console.log('data: ', data); // {family_name: "User1", given_name: "User1", name: "user1"}
+          console.log('user info: ', data); // {family_name: "User1", given_name: "User1", name: "user1"}
           this.context.setCurrentUser(data);
           this.setState({ needLoading: false });
         })

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroup.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroup.js
@@ -55,7 +55,7 @@ const WorkingGroup = ({ formik, fullWorkingGroupList, isLoading }) => {
 
   const removeWorkingGroupCall = (arrayHelpersRemove, index, id) => {
     // Call API to remove
-    console.log('you called DELETE method with id: ' + id);
+    console.log('you called DELETE method with id: ', id);
     deleteData(
       currentFormId,
       end_point.working_groups,
@@ -89,9 +89,12 @@ const WorkingGroup = ({ formik, fullWorkingGroupList, isLoading }) => {
                   getOptionLabel={(option) =>
                     option?.label ? option.label : ''
                   }
+                  getOptionSelected={(option, value) =>
+                    option.value === value.value
+                  }
                   fullWidth={true}
                   onChange={(ev, value) => {
-                    // need to clear the participation level when user selects another working group
+                    // this to clear the participation level when user selects another working group
                     formik.setFieldValue(
                       `workingGroups.${index}.participationLevel`,
                       ''
@@ -167,7 +170,7 @@ const WorkingGroup = ({ formik, fullWorkingGroupList, isLoading }) => {
                         removeWorkingGroupCall(
                           arrayHelpers.remove,
                           index,
-                          workingGroupsLabel[index].id
+                          formik.values.workingGroups[index].id
                         )
                       }
                     >

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupParticipationLevel.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupParticipationLevel.js
@@ -42,7 +42,7 @@ const ParticipationLevel = ({
       setParticipationLevelOptions(temp?.participation_levels);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workingGroupUserJoined]);
+  }, [workingGroupUserJoined, fullWorkingGroupList]);
 
   return (
     <>
@@ -53,7 +53,7 @@ const ParticipationLevel = ({
       <div className="row">
         <div className="col-md-12">
           <Autocomplete
-            options={participationLevelOptions}
+            options={participationLevelOptions || []}
             getOptionLabel={(option) => (option ? option : '')}
             fullWidth={true}
             onChange={(ev, value) => {

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -31,8 +31,8 @@ import { FormikProvider } from 'formik';
  *    - formField: the form field in formModels/formFieldModel.js
  */
 
-const WorkingGroupsWrapper = ({ formik, isStartNewForm }) => {
-  const { currentFormId, furthestPage } = useContext(MembershipContext);
+const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
+  const { currentFormId } = useContext(MembershipContext);
   const [isLoading, setIsLoading] = useState(true);
   const [workingGroupsUserJoined, setWorkingGroupsUserJoined] = useState([]);
   const [fullWorkingGroupList, setFullWorkingGroupList] = useState([]);
@@ -107,11 +107,16 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm }) => {
   }, []);
 
   useEffect(() => {
+    // console.log('use effect....', formik.values);
+
     if (isStartNewForm) {
-      if (furthestPage.index > 1 && !formik.values.workingGroups[0]?.id) {
+      if (furthestPage.index > 3 && !formik.values.workingGroups[0]?.id) {
         // This means user already submitted/finished this page, and comes back from a further page/step
         // so, we need to GET the info user submitted and if user changes anything,
         // we will use the organization_id from the GET to do the PUT to update the info.
+        if (fullWorkingGroupList.length > 0) {
+          fetchWorkingGroupsUserJoined();
+        }
         setIsLoading(false);
       } else {
         // This means this is the 1st time the user see this page,
@@ -119,11 +124,13 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm }) => {
         // no need to do any API call
         setIsLoading(false);
       }
-    } else {
+    } else if (!formik.values.workingGroups[0]?.id) {
       // continue with an existing one
       if (fullWorkingGroupList.length > 0) {
         fetchWorkingGroupsUserJoined();
       }
+    } else {
+      setIsLoading(false);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -108,7 +108,6 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm }) => {
 
   useEffect(() => {
     if (isStartNewForm) {
-      console.log('formik.values: ', formik.values);
       if (furthestPage.index > 1 && !formik.values.workingGroups[0]?.id) {
         // This means user already submitted/finished this page, and comes back from a further page/step
         // so, we need to GET the info user submitted and if user changes anything,

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -31,8 +31,8 @@ import { FormikProvider } from 'formik';
  *    - formField: the form field in formModels/formFieldModel.js
  */
 
-const WorkingGroupsWrapper = ({ formik }) => {
-  const { currentFormId } = useContext(MembershipContext);
+const WorkingGroupsWrapper = ({ formik, isStartNewForm }) => {
+  const { currentFormId, furthestPage } = useContext(MembershipContext);
   const [isLoading, setIsLoading] = useState(true);
   const [workingGroupsUserJoined, setWorkingGroupsUserJoined] = useState([]);
   const [fullWorkingGroupList, setFullWorkingGroupList] = useState([]);
@@ -107,9 +107,26 @@ const WorkingGroupsWrapper = ({ formik }) => {
   }, []);
 
   useEffect(() => {
-    if (fullWorkingGroupList.length > 0) {
-      fetchWorkingGroupsUserJoined();
+    if (isStartNewForm) {
+      console.log('formik.values: ', formik.values);
+      if (furthestPage.index > 1 && !formik.values.workingGroups[0]?.id) {
+        // This means user already submitted/finished this page, and comes back from a further page/step
+        // so, we need to GET the info user submitted and if user changes anything,
+        // we will use the organization_id from the GET to do the PUT to update the info.
+        setIsLoading(false);
+      } else {
+        // This means this is the 1st time the user see this page,
+        // or the user already got the organizations.id
+        // no need to do any API call
+        setIsLoading(false);
+      }
+    } else {
+      // continue with an existing one
+      if (fullWorkingGroupList.length > 0) {
+        fetchWorkingGroupsUserJoined();
+      }
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fullWorkingGroupList]);
 

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -37,77 +37,74 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
   const [workingGroupsUserJoined, setWorkingGroupsUserJoined] = useState([]);
   const [fullWorkingGroupList, setFullWorkingGroupList] = useState([]);
 
-  // Fetch the full availabe working group list that user can join
-  const fetchAvailableFullWorkingGroupList = () => {
-    fetch('workingGroups.json', { headers: FETCH_HEADER })
-      .then((res) => res.json())
-      .then((data) => {
-        let options = data.working_groups.map((item) => ({
-          label: item.name,
-          value: item.id,
-          participation_levels: item.participation_levels,
-        }));
-        setFullWorkingGroupList(options);
-      });
-  };
-
-  // Fetch the working groups user has joined
-  const fetchWorkingGroupsUserJoined = () => {
-    // All pre-process: if running without server,
-    // use fake json data; if running with API, use API
-
-    let url_prefix_local;
-    let url_suffix_local = '';
-    if (getCurrentMode() === MODE_REACT_ONLY) {
-      url_prefix_local = 'membership_data';
-      url_suffix_local = '.json';
-    }
-
-    if (getCurrentMode() === MODE_REACT_API) {
-      url_prefix_local = api_prefix_form;
-    }
-
-    // If the current form exsits, and it is not creating a new form
-    if (currentFormId && currentFormId !== newForm_tempId) {
-      fetch(
-        url_prefix_local +
-          `/${currentFormId}/` +
-          end_point.working_groups +
-          url_suffix_local,
-        { headers: FETCH_HEADER }
-      )
-        .then((resp) => resp.json())
-        .then((data) => {
-          if (data.length) {
-            // matchWorkingGroupFields(): Call the the function to map
-            // the retrived working groups backend data to fit frontend, and
-            // setFieldValue(): Prefill Data --> Call the setFieldValue
-            // of Formik, to set workingGroups field with the mapped data
-            const theGroupsUserJoined = matchWorkingGroupFields(
-              data,
-              fullWorkingGroupList
-            );
-            setWorkingGroupsUserJoined(theGroupsUserJoined);
-            formik.setFieldValue('workingGroups', theGroupsUserJoined);
-          }
-          setIsLoading(false);
-        });
-    } else {
-      setIsLoading(false);
-    }
-  };
-
   // Fetch data only once and prefill data, as long as
   // fetchWorkingGroupsData Function does not change,
   // will not cause re-render again
   useEffect(() => {
-    // Fetch full availabe working group list
+    // Fetch the full availabe working group list that user can join
+    const fetchAvailableFullWorkingGroupList = () => {
+      fetch('workingGroups.json', { headers: FETCH_HEADER })
+        .then((res) => res.json())
+        .then((data) => {
+          let options = data.working_groups.map((item) => ({
+            label: item.name,
+            value: item.id,
+            participation_levels: item.participation_levels,
+          }));
+          setFullWorkingGroupList(options);
+        });
+    };
+
     fetchAvailableFullWorkingGroupList();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    // console.log('use effect....', formik.values);
+    // Fetch the working groups user has joined
+    const fetchWorkingGroupsUserJoined = () => {
+      // All pre-process: if running without server,
+      // use fake json data; if running with API, use API
+
+      let url_prefix_local;
+      let url_suffix_local = '';
+      if (getCurrentMode() === MODE_REACT_ONLY) {
+        url_prefix_local = 'membership_data';
+        url_suffix_local = '.json';
+      }
+
+      if (getCurrentMode() === MODE_REACT_API) {
+        url_prefix_local = api_prefix_form;
+      }
+
+      // If the current form exsits, and it is not creating a new form
+      if (currentFormId && currentFormId !== newForm_tempId) {
+        fetch(
+          url_prefix_local +
+            `/${currentFormId}/` +
+            end_point.working_groups +
+            url_suffix_local,
+          { headers: FETCH_HEADER }
+        )
+          .then((resp) => resp.json())
+          .then((data) => {
+            if (data.length) {
+              // matchWorkingGroupFields(): Call the the function to map
+              // the retrived working groups backend data to fit frontend, and
+              // setFieldValue(): Prefill Data --> Call the setFieldValue
+              // of Formik, to set workingGroups field with the mapped data
+              const theGroupsUserJoined = matchWorkingGroupFields(
+                data,
+                fullWorkingGroupList
+              );
+              setWorkingGroupsUserJoined(theGroupsUserJoined);
+              formik.setFieldValue('workingGroups', theGroupsUserJoined);
+            }
+            setIsLoading(false);
+          });
+      } else {
+        setIsLoading(false);
+      }
+    };
 
     if (isStartNewForm) {
       if (furthestPage.index > 3 && !formik.values.workingGroups[0]?.id) {

--- a/src/main/www/src/components/UIComponents/Button/CustomStepButton.js
+++ b/src/main/www/src/components/UIComponents/Button/CustomStepButton.js
@@ -12,7 +12,7 @@ import MembershipContext from '../../../Context/MembershipContext';
  *   - isSubmitting: boolean, wehther the form is performing submit action; When the form is submitting, you can disable the button or show a spinning, so that the user won't click several times to submit repeatedly
  *   - isLastStep: boolean, whether it's the final step (preview step) or not
  */
-const CustomStepButton = ({ previousPage, nextPage, pageIndex }) => {
+const CustomStepButton = ({ previousPage, nextPage }) => {
   return (
     <div className="button-container margin-top-20 margin-bottom-20">
       {previousPage ? (

--- a/src/main/www/src/components/UIComponents/FormComponents/formFieldModel.js
+++ b/src/main/www/src/components/UIComponents/FormComponents/formFieldModel.js
@@ -63,7 +63,7 @@ export const initialValues = {
   },
 
   // Step 2
-  'membershipLevel-label': '',
+  'membershipLevel-label': { label: '', value: '' },
   membershipLevel: '',
 
   // Step 3: working groups

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -47,9 +47,9 @@ const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
 
           if (data.length > 0) {
             setHasExistingForm(data[0]?.id);
+            setCurrentFormId(data[0]?.id);
           } else {
             setHasExistingForm(false);
-            setCurrentFormId(data[0]?.id);
             handleNewForm(setCurrentFormId, goToCompanyInfoStep);
           }
         })

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -1,70 +1,95 @@
 import MembershipContext from '../../../Context/MembershipContext';
-import { NavLink } from 'react-router-dom';
 import {
   FETCH_HEADER,
   api_prefix_form,
-  newForm_tempId,
   getCurrentMode,
   MODE_REACT_ONLY,
   MODE_REACT_API,
 } from '../../../Constants/Constants';
+import { handleNewForm } from '../../../Utils/formFunctionHelpers';
+import { useContext, useEffect, useState } from 'react';
+import Loading from '../Loading/Loading';
 
 const styles = {
   marginBottom: '20px',
   textAlign: 'center',
 };
 
-const FormChooser = ({ setFurthestPage }) => {
-  const fetchExistingForm = (setCurrentFormId) => {
-    let url_prefix_local;
-    if (getCurrentMode() === MODE_REACT_ONLY) {
-      url_prefix_local = 'membership_data/form_1/form.json';
-    }
+const FormChooser = ({ setFurthestPage, history }) => {
+  const { setCurrentFormId } = useContext(MembershipContext);
+  const [hasExistingForm, setHasExistingForm] = useState('');
 
-    if (getCurrentMode() === MODE_REACT_API) {
-      url_prefix_local = api_prefix_form;
-    }
-
-    fetch(url_prefix_local, { headers: FETCH_HEADER })
-      .then((res) => res.json())
-      .then((data) => {
-        setCurrentFormId(data[0]?.id);
-        console.log(data[0]?.id);
-      })
-      .catch((err) => console.log(err));
+  const goToCompanyInfoStep = () => {
+    setFurthestPage({ index: 1, pathName: '/company-info' });
+    history.push('/company-info');
   };
 
+  useEffect(() => {
+    const fetchExistingForms = () => {
+      let url_prefix_local;
+      if (getCurrentMode() === MODE_REACT_ONLY) {
+        url_prefix_local = 'membership_data/form_1/form.json';
+      }
+
+      if (getCurrentMode() === MODE_REACT_API) {
+        url_prefix_local = api_prefix_form;
+      }
+
+      fetch(url_prefix_local, { headers: FETCH_HEADER })
+        .then((res) => res.json())
+        .then((data) => {
+          console.log('existing forms:  ', data);
+
+          if (data.length > 0) {
+            setHasExistingForm(data[0]?.id);
+          } else {
+            setHasExistingForm(false);
+            setCurrentFormId(data[0]?.id);
+            goToCompanyInfoStep();
+          }
+        })
+        .catch((err) => console.log(err));
+    };
+
+    fetchExistingForms();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <MembershipContext.Consumer>
-      {({ setCurrentFormId }) => (
-        <div style={styles}>
-          <h1 className="h3 padding-bottom-10">
-            Welcome back! You can continue the application you previously
-            started or start a new application.
-          </h1>
-          <button
-            type="button"
-            onClick={() => {
-              setFurthestPage({ index: 1, pathName: '/company-info' });
-              fetchExistingForm(setCurrentFormId);
-            }}
-            className="btn btn-primary"
-          >
-            <NavLink to="/company-info">Continue Existing Application</NavLink>
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setFurthestPage({ index: 1, pathName: '/company-info' });
-              setCurrentFormId(newForm_tempId);
-            }}
-            className="btn btn-primary"
-          >
-            <NavLink to="/company-info">Start New Application</NavLink>
-          </button>
-        </div>
-      )}
-    </MembershipContext.Consumer>
+    <>
+      {
+        // if hasExistingForm equals to '' means the fetch call is not completed yet, so show loading animation
+        hasExistingForm === '' ? (
+          <Loading />
+        ) : (
+          <div style={styles}>
+            <h1 className="h3 padding-bottom-10">
+              Welcome back! You can continue the application you previously
+              started or start a new application.
+            </h1>
+            {!!hasExistingForm && (
+              <button
+                type="button"
+                onClick={goToCompanyInfoStep}
+                className="btn btn-primary"
+              >
+                Continue Existing Application
+              </button>
+            )}
+
+            <button
+              type="button"
+              onClick={() => {
+                handleNewForm(setCurrentFormId, goToCompanyInfoStep);
+              }}
+              className="btn btn-primary"
+            >
+              Start New Application
+            </button>
+          </div>
+        )
+      }
+    </>
   );
 };
 

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -50,7 +50,7 @@ const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
           } else {
             setHasExistingForm(false);
             setCurrentFormId(data[0]?.id);
-            goToCompanyInfoStep();
+            handleNewForm(setCurrentFormId, goToCompanyInfoStep);
           }
         })
         .catch((err) => console.log(err));

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -15,13 +15,18 @@ const styles = {
   textAlign: 'center',
 };
 
-const FormChooser = ({ setFurthestPage, history }) => {
+const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
   const { setCurrentFormId } = useContext(MembershipContext);
   const [hasExistingForm, setHasExistingForm] = useState('');
 
   const goToCompanyInfoStep = () => {
     setFurthestPage({ index: 1, pathName: '/company-info' });
     history.push('/company-info');
+  };
+
+  const handleContinueExistingForm = () => {
+    setIsStartNewForm(false);
+    goToCompanyInfoStep();
   };
 
   useEffect(() => {
@@ -70,7 +75,7 @@ const FormChooser = ({ setFurthestPage, history }) => {
             {!!hasExistingForm && (
               <button
                 type="button"
-                onClick={goToCompanyInfoStep}
+                onClick={handleContinueExistingForm}
                 className="btn btn-primary"
               >
                 Continue Existing Application

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -46,8 +46,8 @@ const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
           console.log('existing forms:  ', data);
 
           if (data.length > 0) {
-            setHasExistingForm(data[0]?.id);
-            setCurrentFormId(data[0]?.id);
+            setHasExistingForm(data[data.length - 1]?.id);
+            setCurrentFormId(data[data.length - 1]?.id);
           } else {
             setHasExistingForm(false);
             handleNewForm(setCurrentFormId, goToCompanyInfoStep);


### PR DESCRIPTION
For [issue37](https://github.com/EclipseFdn/react-eclipsefdn-members/issues/37) and [issue18](https://github.com/EclipseFdn/react-eclipsefdn-members/issues/18)

Now, after the user sign in, it will work like this:

- First, check if there is any existing form created by this user.
- If there is no existing form, the user will be led to the company info step/page.
- If there is at least one existing form, the user will see 2 options, "Continue Existing Application" and "Start New Application"
- For "Start New Application", the app will create a new empty form for the user and let the user fill up all required info.
- For "Continue Existing Application", the app will use the latest form for the user.
- Create new forms (organization, membership level, working groups etc.)  when user chooses "Start New Application" and hits "Next/Submit" button
- When user chooses "Start New Application", the app won't do a GET API call to back end because there is no data, but will do so if user comes back from a later/further page so that the app can get the id for doing PUT API call to update the form.
- Prefill the form with existing data when user chooses "Continue Existing Application"
- Update existing forms (organization, membership level, working groups etc.) when user chooses "Continue Existing Application" and hits "Next" button, 
