### PR TITLE
Improved the useEffect usage

### DIFF
--- a/src/main/www/package.json
+++ b/src/main/www/package.json
@@ -53,5 +53,9 @@
     "react-datepicker": "^3.2.2",
     "react-select": "^4.1.0",
     "yup": "^0.32.8"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "printWidth": 80
   }
 }

--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -469,9 +469,7 @@ export function deleteData(formId, endpoint, entityId, callback, index) {
  * - Send the API calls to organizations and contacts
  * **/
 export async function handleNewForm(setCurrentFormId, defaultBehaviour) {
-  if (getCurrentMode() === MODE_REACT_ONLY) {
-    defaultBehaviour();
-  }
+  defaultBehaviour();
 
   if (getCurrentMode() === MODE_REACT_API) {
     var dataBody = {
@@ -488,7 +486,6 @@ export async function handleNewForm(setCurrentFormId, defaultBehaviour) {
       .then((data) => {
         console.log('Start with a new form:', data);
         setCurrentFormId(data[0]?.id);
-        defaultBehaviour();
       })
       .catch((err) => console.log(err));
   }

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
@@ -120,7 +120,6 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
         // so, we need to GET the info user submitted and if user changes anything,
         // we will use the organization_id from the GET to do the PUT to update the info.
         detectModeAndFetch();
-        setLoading(false);
       } else {
         // This means this is the 1st time the user see this page,
         // or the user already got the organizations.id

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
@@ -113,7 +113,7 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
       if (
         furthestPage.index > 1 &&
         !formik.values.organization?.id &&
-        window.location.pathname === '/company-info'
+        window.location.hash === '#company-info'
         // the last condition is to avoid "can't perform a React state update on unmounted component" error
       ) {
         // This means user already submitted/finished this page, and comes back from a further page/step

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
@@ -33,9 +33,6 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
   const { currentFormId, furthestPage } = useContext(MembershipContext); // current chosen form id
   const [loading, setLoading] = useState(true);
 
-  // Fetch data only once and prefill data,
-  // as long as currentFormId and setFieldValue
-  // Function does not change, will not cause re-render again
   useEffect(() => {
     const detectModeAndFetch = () => {
       // Once we have API set up ready, we don't need the
@@ -59,7 +56,7 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
       if (getCurrentMode() === MODE_REACT_API) {
         url_prefix_local = api_prefix_form;
       }
-      // If the current form exsits, and it is not creating a new form
+      // If the current form id exsits
       if (currentFormId) {
         // Using promise pool, because in first step,
         // need to get company data, and contacts data
@@ -113,7 +110,12 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
     };
 
     if (isStartNewForm) {
-      if (furthestPage.index > 1 && !formik.values.organization?.id) {
+      if (
+        furthestPage.index > 1 &&
+        !formik.values.organization?.id &&
+        window.location.pathname === '/company-info'
+        // the last condition is to avoid "can't perform a React state update on unmounted component" error
+      ) {
         // This means user already submitted/finished this page, and comes back from a further page/step
         // so, we need to GET the info user submitted and if user changes anything,
         // we will use the organization_id from the GET to do the PUT to update the info.
@@ -134,8 +136,7 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
       // user already has the data, no need to do any API call
       setLoading(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isStartNewForm, formik, currentFormId, furthestPage.index]);
 
   // If it is in loading status,
   // only return a loading spinning

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
@@ -187,9 +187,7 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
       // then it means this is the 1st time the user see this page
       // need to GET the data
       if (!hasOrgData) detectModeAndFetch();
-
       if (!hasMembershipLevelData) detectModeAndFetchMembershipLevel();
-
       if (hasOrgData && hasMembershipLevelData) setLoading(false);
     }
   }, [isStartNewForm, setFieldValue, currentFormId]);

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformation.js
@@ -43,9 +43,13 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+let hasOrgData = false;
+let hasMembershipLevelData = false;
+
 const CompanyInformation = ({ formik, isStartNewForm }) => {
-  const { currentFormId, furthestPage } = useContext(MembershipContext); // current chosen form id
+  const { currentFormId } = useContext(MembershipContext); // current chosen form id
   const [loading, setLoading] = useState(true);
+  const { setFieldValue } = formik;
 
   useEffect(() => {
     const detectModeAndFetch = () => {
@@ -104,8 +108,10 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
               // organization field with the mapped data,
               // if nested, it will automatically map the
               // properties and values
-              formik.setFieldValue('organization', tempOrg);
+              setFieldValue('organization', tempOrg);
+              hasOrgData = true;
             }
+
             if (contacts.length) {
               // Call the the function to map the retrived contacts
               // (company representative, marketing rep, accounting rep)
@@ -114,15 +120,16 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
               // Prefill Data --> Call the setFieldValue of Formik,
               // to set representative field with the mapped data,
               // if nested, it will automatically map the properties and values
-              formik.setFieldValue(
+              setFieldValue(
                 'representative',
                 tempContacts.organizationContacts
               );
 
-              formik.setFieldValue(
+              setFieldValue(
                 'signingAuthorityRepresentative',
                 tempContacts.signingAuthorityRepresentative
               );
+              hasOrgData = true;
             }
             setLoading(false);
           });
@@ -159,17 +166,12 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
                 data[0]?.membership_level,
                 MEMBERSHIP_LEVELS
               );
-              formik.setFieldValue(
-                'membershipLevel',
-                tempMembershipLevel.value
-              );
-              formik.setFieldValue(
-                'membershipLevel-label',
-                tempMembershipLevel
-              );
+              setFieldValue('membershipLevel', tempMembershipLevel.value);
+              setFieldValue('membershipLevel-label', tempMembershipLevel);
 
               const tempPurchasingAndVAT = mapPurchasingAndVAT(data[0]);
-              formik.setFieldValue('purchasingAndVAT', tempPurchasingAndVAT);
+              setFieldValue('purchasingAndVAT', tempPurchasingAndVAT);
+              hasMembershipLevelData = true;
             }
             setLoading(false);
           });
@@ -179,33 +181,18 @@ const CompanyInformation = ({ formik, isStartNewForm }) => {
     };
 
     if (isStartNewForm) {
-      if (
-        furthestPage.index > 1 &&
-        !formik.values.organization?.id &&
-        window.location.hash === '#company-info'
-        // the last condition is to avoid "can't perform a React state update on unmounted component" error
-      ) {
-        // This means user already submitted/finished this page, and comes back from a further page/step
-        // so, we need to GET the info user submitted and if user changes anything,
-        // we will use the organization_id from the GET to do the PUT to update the info.
-        detectModeAndFetch();
-      } else {
-        // This means this is the 1st time the user see this page,
-        // or the user already got the organizations.id
-        // no need to do any API call
-        setLoading(false);
-      }
-    } else if (!formik.values.organization?.id) {
-      // continue with an existing one, if there is no id saved locally
+      setLoading(false);
+    } else {
+      // continue with an existing one, if there is no data saved locally
       // then it means this is the 1st time the user see this page
       // need to GET the data
-      detectModeAndFetch();
-      detectModeAndFetchMembershipLevel();
-    } else {
-      // user already has the data, no need to do any API call
-      setLoading(false);
+      if (!hasOrgData) detectModeAndFetch();
+
+      if (!hasMembershipLevelData) detectModeAndFetchMembershipLevel();
+
+      if (hasOrgData && hasMembershipLevelData) setLoading(false);
     }
-  }, [isStartNewForm, formik, currentFormId, furthestPage.index]);
+  }, [isStartNewForm, setFieldValue, currentFormId]);
 
   // If it is in loading status,
   // only return a loading spinning

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
@@ -93,7 +93,7 @@ const Contacts = ({ formik }) => {
             requiredMark={true}
             disableInput={disableInput}
             onChange={
-              type === 'company'
+              type === 'member'
                 ? (ev) => handleMemberInputChange(ev.target.value, el.name)
                 : formik.handleChange
             }

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import Input from '../../UIComponents/Inputs/Input';
 import { formField } from '../../UIComponents/FormComponents/formFieldModel';
 import { Checkbox, FormControlLabel } from '@material-ui/core';
@@ -37,31 +36,45 @@ const Contacts = ({ formik }) => {
    * @param disableInput - if marketing / accounting is the same as company Rep., mark the input disabled and just used the same values from company Rep.
    */
 
-  // update representative.marketing values based on related checkbox
-  useEffect(() => {
+  const handleCheckboxChange = (isChecked, fieldName) => {
+    const repInfo = isChecked
+      ? formik.values.representative.company
+      : formik.values.representative[fieldName];
+
+    const newValues = {
+      ...repInfo,
+      sameAsCompany: isChecked,
+    };
+    formik.setFieldValue(`representative.${fieldName}`, newValues);
+  };
+
+  const handleMemberInputChange = (value, name) => {
+    const memberRepInfo = {
+      ...formik.values.representative.company,
+      [name]: value,
+    };
+    formik.setFieldValue('representative.company', memberRepInfo);
+
+    // update representative.marketing values based on related checkbox
     if (isMarketingSameAsCompany) {
       const newValues = {
-        ...formik.values.representative.company,
+        ...memberRepInfo,
         id: formik.values.representative.marketing.id || '',
-        sameAsCompany: formik.values.representative.marketing.sameAsCompany,
+        sameAsCompany: isMarketingSameAsCompany,
       };
       formik.setFieldValue('representative.marketing', newValues);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMarketingSameAsCompany, formik.values.representative.company]);
 
-  // update representative.accounting values based on related checkbox
-  useEffect(() => {
+    // update representative.accounting values based on related checkbox
     if (isAccountingSameAsCompany) {
       const newValues = {
-        ...formik.values.representative.company,
+        ...memberRepInfo,
         id: formik.values.representative.accounting.id || '',
-        sameAsCompany: formik.values.representative.accounting.sameAsCompany,
+        sameAsCompany: isAccountingSameAsCompany,
       };
       formik.setFieldValue('representative.accounting', newValues);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAccountingSameAsCompany, formik.values.representative.company]);
+  };
 
   const generateContacts = (
     representativeFields,
@@ -79,7 +92,11 @@ const Contacts = ({ formik }) => {
             placeholder={el.placeholder}
             requiredMark={true}
             disableInput={disableInput}
-            onChange={formik.handleChange}
+            onChange={
+              type === 'company'
+                ? (ev) => handleMemberInputChange(ev.target.value, el.name)
+                : formik.handleChange
+            }
             value={formik.values.representative[`${type}`][`${el.name}`]}
             error={
               formik.touched.representative?.[`${type}`]?.[`${el.name}`] &&
@@ -116,7 +133,7 @@ const Contacts = ({ formik }) => {
       <div className="row">
         {generateContacts(companyRep, 'company-rep', 'company', false)}
       </div>
-
+      
       <h4 className="fw-600" id="marketing-rep">
         Company Marketing Representative
       </h4>
@@ -126,7 +143,9 @@ const Contacts = ({ formik }) => {
             name="representative.marketing.sameAsCompany"
             color="primary"
             checked={formik.values.representative.marketing.sameAsCompany}
-            onChange={formik.handleChange}
+            onChange={(ev) =>
+              handleCheckboxChange(ev.target.checked, 'marketing')
+            }
           />
         }
         label="Same as member rep."
@@ -150,7 +169,9 @@ const Contacts = ({ formik }) => {
             name="representative.accounting.sameAsCompany"
             color="primary"
             checked={isAccountingSameAsCompany}
-            onChange={formik.handleChange}
+            onChange={(ev) =>
+              handleCheckboxChange(ev.target.checked, 'accounting')
+            }
           />
         }
         label="Same as member rep."

--- a/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
+++ b/src/main/www/src/components/Pages/CompanyInformation/CompanyInformationContacts.js
@@ -97,14 +97,14 @@ const Contacts = ({ formik }) => {
                 ? (ev) => handleMemberInputChange(ev.target.value, el.name)
                 : formik.handleChange
             }
-            value={formik.values.representative[`${type}`][`${el.name}`]}
+            value={formik.values.representative?.[type]?.[el.name]}
             error={
-              formik.touched.representative?.[`${type}`]?.[`${el.name}`] &&
-              Boolean(formik.errors.representative?.[`${type}`]?.[`${el.name}`])
+              formik.touched.representative?.[type]?.[el.name] &&
+              Boolean(formik.errors.representative?.[type]?.[el.name])
             }
             helperText={
-              formik.touched.representative?.[`${type}`]?.[`${el.name}`] &&
-              formik.errors.representative?.[`${type}`]?.[`${el.name}`]
+              formik.touched.representative?.[type]?.[el.name] &&
+              formik.errors.representative?.[type]?.[el.name]
             }
           />
         </div>

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -127,12 +127,12 @@ export default function Main() {
   return (
     <div className="container eclipseFdn-membership-webform">
       <>
-        {window.location.pathname === '/' ||
-        window.location.pathname === '/sign-in' ? (
+        {window.location.hash === '/' ||
+        window.location.hash === '#sign-in' ? (
           <SignInIntroduction />
         ) : null}
 
-        {window.location.pathname !== '/submitted' && renderStepper()}
+        {window.location.hash !== '#submitted' && renderStepper()}
 
         <Switch>
           <Route exact path="/">
@@ -204,6 +204,7 @@ export default function Main() {
               <Redirect to={furthestPage.pathName} />
             )}
           </Route>
+
           <Route path="/submitted">
             {furthestPage.index >= 6 ? (
               <SubmitSuccess />

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -2,10 +2,7 @@ import { useContext, useState } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import { useFormik } from 'formik';
 import SignIn from './SignIn/SignIn';
-import {
-  COMPANY_INFORMATION,
-  PAGE_STEP,
-} from '../../Constants/Constants';
+import { COMPANY_INFORMATION, PAGE_STEP } from '../../Constants/Constants';
 import {
   formField,
   initialValues,

--- a/src/main/www/src/components/Pages/Main.js
+++ b/src/main/www/src/components/Pages/Main.js
@@ -45,6 +45,12 @@ export default function Main() {
     });
   };
 
+  const updateSigningAuthorityForm = (values) => {
+    values.forEach((item) => {
+      formikSigningAuthority.setFieldValue(item.field, item.value);
+    });
+  };
+
   const formikCompanyInfo = useFormik({
     initialValues: initialValues,
     validationSchema: validationSchema[0],
@@ -70,15 +76,38 @@ export default function Main() {
       setUpdatedFormValues(theNewValue);
       console.log('updated company info: ', values);
 
-      const valueToUpdateFormik = [
+      const valueForMembershipLevelFormik = [
         { field: 'purchasingAndVAT', value: purchasingAndVAT },
         { field: 'membershipLevel', value: membershipLevel },
         { field: 'membershipLevel-label', value: membershipLevelLabel },
       ];
       // set valueToUpdateFormik to membershipLevel formik to make sure the value is up to date
-      updateMembershipLevelForm(valueToUpdateFormik);
+      updateMembershipLevelForm(valueForMembershipLevelFormik);
 
-      executeSendDataByStep(1, theNewValue, currentFormId, currentUser.name);
+      const valueForSigningAuthorityFormik = [
+        {
+          field: 'signingAuthorityRepresentative',
+          value: signingAuthorityRepresentative,
+        },
+      ];
+      updateSigningAuthorityForm(valueForSigningAuthorityFormik);
+
+      const setFieldValueObj = {
+        fieldName: {
+          organization: 'organization',
+          member: 'representative.member',
+          accounting: 'representative.accounting',
+          marketing: 'representative.marketing',
+        },
+        method: formikCompanyInfo.setFieldValue,
+      };
+      executeSendDataByStep(
+        1,
+        theNewValue,
+        currentFormId,
+        currentUser.name,
+        setFieldValueObj
+      );
 
       goToNextStep(1, '/membership-level');
     },
@@ -120,7 +149,17 @@ export default function Main() {
       setUpdatedFormValues({ ...updatedFormValues, workingGroups });
       console.log('updated working groups: ', values);
 
-      executeSendDataByStep(3, values, currentFormId, currentUser.name);
+      const setFieldValueObj = {
+        fieldName: 'workingGroups',
+        method: formikWorkingGroups.setFieldValue,
+      };
+      executeSendDataByStep(
+        3,
+        values,
+        currentFormId,
+        currentUser.name,
+        setFieldValueObj
+      );
 
       goToNextStep(3, '/signing-authority');
     },
@@ -147,7 +186,20 @@ export default function Main() {
       ];
       // set valueToUpdateFormik to CompanyInfo formik to make sure the value is up to date
       updateCompanyInfoForm(valueToUpdateFormik);
-      executeSendDataByStep(4, values, currentFormId, currentUser.name);
+      const setFieldValueObj = {
+        fieldName: 'signingAuthorityRepresentative',
+        method: {
+          signingAuthority: formikSigningAuthority.setFieldValue,
+          companyInfo: formikCompanyInfo.setFieldValue,
+        },
+      };
+      executeSendDataByStep(
+        4,
+        values,
+        currentFormId,
+        currentUser.name,
+        setFieldValueObj
+      );
 
       goToNextStep(4, '/review');
     },
@@ -175,8 +227,7 @@ export default function Main() {
   return (
     <div className="container eclipseFdn-membership-webform">
       <>
-        {window.location.hash === '/' ||
-        window.location.hash === '#sign-in' ? (
+        {window.location.hash === '/' || window.location.hash === '#sign-in' ? (
           <SignInIntroduction />
         ) : null}
 

--- a/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
+++ b/src/main/www/src/components/Pages/MembershipLevel/MembershipLevel.js
@@ -7,7 +7,6 @@ import {
   api_prefix_form,
   FETCH_HEADER,
   membership_levels,
-  newForm_tempId,
   getCurrentMode,
   MODE_REACT_ONLY,
   MODE_REACT_API,
@@ -40,9 +39,6 @@ const MembershipLevel = ({ formik, isStartNewForm }) => {
 
   const [loading, setLoading] = useState(true);
 
-  // Fetch data only once and prefill data, as long as
-  // currentFormId, membershipLevel.name and setFieldValue
-  // Function does not change, will not cause re-render again
   useEffect(() => {
     // All pre-process: if running without server,
     // use fake json data; if running with API, use API
@@ -61,8 +57,8 @@ const MembershipLevel = ({ formik, isStartNewForm }) => {
         url_prefix_local = api_prefix_form;
       }
 
-      // If the current form exsits, and it is not creating a new form
-      if (currentFormId && currentFormId !== newForm_tempId) {
+      // If the current form id exsits
+      if (currentFormId) {
         fetch(url_prefix_local + `/${currentFormId}` + url_suffix_local, {
           headers: FETCH_HEADER,
         })
@@ -102,9 +98,7 @@ const MembershipLevel = ({ formik, isStartNewForm }) => {
     } else {
       setLoading(false);
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentFormId]);
+  }, [isStartNewForm, formik, currentFormId]);
 
   if (loading) {
     return <Loading />;

--- a/src/main/www/src/components/Pages/SigningAuthority/SigningAuthority.js
+++ b/src/main/www/src/components/Pages/SigningAuthority/SigningAuthority.js
@@ -1,7 +1,7 @@
 import CustomStepButton from '../../UIComponents/Button/CustomStepButton';
 import Input from '../../UIComponents/Inputs/Input';
 import { formField } from '../../UIComponents/FormComponents/formFieldModel';
-import { useEffect } from 'react';
+
 /**
  * Have not added any API calls here,
  * simply use the form fields to render
@@ -9,17 +9,8 @@ import { useEffect } from 'react';
  */
 
 const sectionName = 'signing-authority';
-const SigningAuthority = ({ formik, updatedFormValues }) => {
+const SigningAuthority = ({ formik }) => {
   const { signingAuthorityRepresentative } = formField;
-
-  useEffect(() => {
-    formik.setFieldValue(
-      'signingAuthorityRepresentative',
-      updatedFormValues.signingAuthorityRepresentative
-    );
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <form onSubmit={formik.handleSubmit}>

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupParticipationLevel.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupParticipationLevel.js
@@ -41,7 +41,6 @@ const ParticipationLevel = ({
       );
       setParticipationLevelOptions(temp?.participation_levels);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workingGroupUserJoined, fullWorkingGroupList]);
 
   return (

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -109,7 +109,7 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
       if (
         furthestPage.index > 3 &&
         !formik.values.workingGroups[0]?.id &&
-        window.location.pathname === '/working-groups'
+        window.location.hash === '#working-groups'
         // the last condition is to avoid "can't perform a React state update on unmounted component" error
       ) {
         // This means user already submitted/finished this page, and comes back from a further page/step

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -32,8 +32,11 @@ import { FormikProvider } from 'formik';
  *    - formField: the form field in formModels/formFieldModel.js
  */
 
-const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
+let hasWGData = false;
+
+const WorkingGroupsWrapper = ({ formik, isStartNewForm }) => {
   const { currentFormId } = useContext(MembershipContext);
+  const { setFieldValue } = formik;
   const [isLoading, setIsLoading] = useState(true);
   const [workingGroupsUserJoined, setWorkingGroupsUserJoined] = useState([]);
   const [fullWorkingGroupList, setFullWorkingGroupList] = useState([]);
@@ -110,7 +113,8 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
                 fullWorkingGroupList
               );
               setWorkingGroupsUserJoined(theGroupsUserJoined);
-              formik.setFieldValue('workingGroups', theGroupsUserJoined);
+              setFieldValue('workingGroups', theGroupsUserJoined);
+              hasWGData = true;
             }
             setIsLoading(false);
           });
@@ -120,26 +124,8 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
     };
 
     if (isStartNewForm) {
-      if (
-        furthestPage.index > 3 &&
-        !formik.values.workingGroups[0]?.id &&
-        window.location.hash === '#working-groups'
-        // the last condition is to avoid "can't perform a React state update on unmounted component" error
-      ) {
-        // This means user already submitted/finished this page, and comes back from a further page/step
-        // so, we need to GET the info user submitted and if user changes anything,
-        // we will use the organization_id from the GET to do the PUT to update the info.
-        if (fullWorkingGroupList.length > 0) {
-          fetchWorkingGroupsUserJoined();
-        }
-        setIsLoading(false);
-      } else {
-        // This means this is the 1st time the user see this page,
-        // or the user already got the organizations.id
-        // no need to do any API call
-        setIsLoading(false);
-      }
-    } else if (!formik.values.workingGroups[0]?.id) {
+      setIsLoading(false);
+    } else if (!hasWGData) {
       // continue with an existing one
       if (fullWorkingGroupList.length > 0) {
         fetchWorkingGroupsUserJoined();
@@ -147,13 +133,7 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
     } else {
       setIsLoading(false);
     }
-  }, [
-    isStartNewForm,
-    formik,
-    currentFormId,
-    furthestPage.index,
-    fullWorkingGroupList,
-  ]);
+  }, [isStartNewForm, currentFormId, fullWorkingGroupList, setFieldValue]);
 
   if (isLoading) {
     return <Loading />;

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -125,11 +125,9 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm }) => {
 
     if (isStartNewForm) {
       setIsLoading(false);
-    } else if (!hasWGData) {
+    } else if (!hasWGData && fullWorkingGroupList.length > 0) {
       // continue with an existing one
-      if (fullWorkingGroupList.length > 0) {
-        fetchWorkingGroupsUserJoined();
-      }
+      fetchWorkingGroupsUserJoined();
     } else {
       setIsLoading(false);
     }

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -123,10 +123,8 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm }) => {
       }
     };
 
-    if (isStartNewForm) {
-      setIsLoading(false);
-    } else if (!hasWGData && fullWorkingGroupList.length > 0) {
-      // continue with an existing one
+    if (!isStartNewForm && !hasWGData && fullWorkingGroupList.length > 0) {
+      // continue with an existing one and there is no working group data
       fetchWorkingGroupsUserJoined();
     } else {
       setIsLoading(false);

--- a/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
+++ b/src/main/www/src/components/Pages/WorkingGroups/WorkingGroupsWrapper.js
@@ -56,7 +56,6 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
     };
 
     fetchAvailableFullWorkingGroupList();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -107,7 +106,12 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
     };
 
     if (isStartNewForm) {
-      if (furthestPage.index > 3 && !formik.values.workingGroups[0]?.id) {
+      if (
+        furthestPage.index > 3 &&
+        !formik.values.workingGroups[0]?.id &&
+        window.location.pathname === '/working-groups'
+        // the last condition is to avoid "can't perform a React state update on unmounted component" error
+      ) {
         // This means user already submitted/finished this page, and comes back from a further page/step
         // so, we need to GET the info user submitted and if user changes anything,
         // we will use the organization_id from the GET to do the PUT to update the info.
@@ -129,9 +133,13 @@ const WorkingGroupsWrapper = ({ formik, isStartNewForm, furthestPage }) => {
     } else {
       setIsLoading(false);
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fullWorkingGroupList]);
+  }, [
+    isStartNewForm,
+    formik,
+    currentFormId,
+    furthestPage.index,
+    fullWorkingGroupList,
+  ]);
 
   if (isLoading) {
     return <Loading />;

--- a/src/main/www/src/components/UIComponents/FormComponents/ValidationSchema.js
+++ b/src/main/www/src/components/UIComponents/FormComponents/ValidationSchema.js
@@ -35,7 +35,7 @@ export const validationSchema = [
   yup.object().shape({
     // First step - representative contacts
     representative: yup.object().shape({
-      company: yup.object().shape({
+      member: yup.object().shape({
         email: yup.string('Enter your email').email('Enter a valid email'),
       }),
       marketing: yup.object().shape({

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -58,7 +58,7 @@ const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
     if (hasExistingForm === '') {
       fetchExistingForms();
     }
-  }, [goToCompanyInfoStep, setCurrentFormId]);
+  }, [goToCompanyInfoStep, setCurrentFormId, hasExistingForm]);
 
   return (
     <>

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -43,7 +43,7 @@ const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
         .then((res) => res.json())
         .then((data) => {
           console.log('existing forms:  ', data);
-          
+
           if (data.length > 0) {
             setHasExistingForm(data[data.length - 1]?.id);
             setCurrentFormId(data[data.length - 1]?.id);
@@ -55,7 +55,9 @@ const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
         .catch((err) => console.log(err));
     };
 
-    fetchExistingForms();
+    if (hasExistingForm === '') {
+      fetchExistingForms();
+    }
   }, [goToCompanyInfoStep, setCurrentFormId]);
 
   return (

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -7,9 +7,8 @@ import {
   MODE_REACT_API,
 } from '../../../Constants/Constants';
 import { handleNewForm } from '../../../Utils/formFunctionHelpers';
-import { useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import Loading from '../Loading/Loading';
-
 const styles = {
   marginBottom: '20px',
   textAlign: 'center',
@@ -19,10 +18,10 @@ const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
   const { setCurrentFormId } = useContext(MembershipContext);
   const [hasExistingForm, setHasExistingForm] = useState('');
 
-  const goToCompanyInfoStep = () => {
+  const goToCompanyInfoStep = useCallback(() => {
     setFurthestPage({ index: 1, pathName: '/company-info' });
     history.push('/company-info');
-  };
+  }, [history, setFurthestPage]);
 
   const handleContinueExistingForm = () => {
     setIsStartNewForm(false);
@@ -44,7 +43,7 @@ const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
         .then((res) => res.json())
         .then((data) => {
           console.log('existing forms:  ', data);
-
+          
           if (data.length > 0) {
             setHasExistingForm(data[data.length - 1]?.id);
             setCurrentFormId(data[data.length - 1]?.id);
@@ -57,8 +56,7 @@ const FormChooser = ({ setFurthestPage, history, setIsStartNewForm }) => {
     };
 
     fetchExistingForms();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [goToCompanyInfoStep, setCurrentFormId]);
 
   return (
     <>


### PR DESCRIPTION
For [issue93](https://github.com/EclipseFdn/react-eclipsefdn-members/issues/93)

- Added all dependencies suggested by ESLint.

- Instead of using useEffect in CompanyInformationContacts component, now it's using onChange (of some input components) to handle the logic

Update on June 18:
Overall, less API calls and less dependencies and if statement conditions in useEffect. Won't unnecessarily trigger useEffect.

- Removed furthestpage from the dependency array by changing the way to get the field id when user chooses "Start New Application".
Instead of getting the field id by doing a GET request, now the field id will be updated after a successful POST request.

- Removed formik from the dependency array by using destructuring to get only the setFieldValue method.

- Removed useEffect in SigningAuthority component, as the update/operation will be triggered when we get the data in CompanyInfo component.