### PR TITLE
Add property to recreate DB on given special profile

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,9 @@ quarkus.oidc.authentication.redirect-path=/login
 quarkus.oidc.logout.post-logout-path=/
 quarkus.oidc.logout.path=/logout
 
+## Recreate DB profile (easy to trigger in remote envs)
+%dbfresh.quarkus.hibernate-orm.database.generation=drop-and-create
+
 ## DEV SETTINGS
 %dev.quarkus.http.port=8090
 %dev.quarkus.oidc.credentials.client-secret.value=4d596003-2cfe-49ba-a7cb-ea3d40bf5538


### PR DESCRIPTION
The idea with this PR is to give an easy way we can trigger a rebuild of the DB through the service on remote pods/environments. All that would need to be done to enable the profile is to `export QUARKUS_PROFILE=dbfresh` or set that environment variable and start the server. After completion, the variable can be cleared, and the DB restarted in the normal profile for standard operation.

While DDL exports are ideal, they can be a little messy with how Hibernate generates and manages tables.