### PR TITLE
Added loading spinner after user chooses start new application

### DIFF
--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -677,15 +677,15 @@ export function deleteData(formId, endpoint, entityId, callback, index) {
  * @param setCurrentFormId - setCurrentFormId function from membership context
  * @param formData - Filled whole form data stored in formik context
  * @param userId - User Id fetched from the server when sign in, sotored in membership context, used for calling APIs
- * @param defaultBehaviour - Go to the next step and add this step to complete set, passed from FormikStepper Component
+ * @param goToCompanyInfoStep - Go to the next step and add this step to complete set, passed from FormikStepper Component
  *
  * The logic:
  * - POST a new form and returned the new form Id
  * - Store the returned new form Id in my FormId Context
  * - Send the API calls to organizations and contacts
  * **/
-export async function handleNewForm(setCurrentFormId, defaultBehaviour) {
-  defaultBehaviour();
+export function handleNewForm(setCurrentFormId, goToCompanyInfoStep) {
+  goToCompanyInfoStep();
 
   if (getCurrentMode() === MODE_REACT_API) {
     var dataBody = {

--- a/src/main/www/src/components/Application/CompanyInformation/CompanyInformation.js
+++ b/src/main/www/src/components/Application/CompanyInformation/CompanyInformation.js
@@ -214,9 +214,9 @@ const CompanyInformation = ({
     }
   }, [isStartNewForm, setFieldValue, currentFormId, redirectTo, handleLoginExpired]);
 
-  // If it is in loading status,
+  // If it is in loading status or hasn't gotten the form id,
   // only return a loading spinning
-  if (loading) {
+  if (loading || !currentFormId) {
     return <Loading />;
   }
 

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -42,6 +42,7 @@ const FormChooser = ({
   };
 
   const handleStartNewForm = () => {
+    setCurrentFormId('');
     // reset the form if user has gone to a further page/step
     if (furthestPage.index > 0) {
       resetCompanyInfoForm();
@@ -76,7 +77,7 @@ const FormChooser = ({
             setHasExistingForm(data[0]?.id);
             setCurrentFormId(data[0]?.id);
           } else {
-            setHasExistingForm(false);
+            setCurrentFormId('');
             handleNewForm(setCurrentFormId, goToCompanyInfoStep);
           }
         })


### PR DESCRIPTION
A loading spinner will show up after user chooses "Start new application" and will disappear after React gets the new form id. 
This will make sure user won't go ahead without a valid form id.