### PR TITLE
Changed the default value for purchase order required field

### DIFF
--- a/src/main/www/src/Utils/formFunctionHelpers.js
+++ b/src/main/www/src/Utils/formFunctionHelpers.js
@@ -662,7 +662,7 @@ export function handleNewForm(setCurrentFormId, goToCompanyInfoStep) {
     var dataBody = {
       membership_level: '',
       signing_authority: false,
-      purchase_order_required: 'na',
+      purchase_order_required: '',
       state: 'INPROGRESS',
     };
 


### PR DESCRIPTION
Removed the default value for purchase order required field to align with the latest validation rule.