### PR TITLE
Fixed backup issue in a specific task flow

### DIFF
--- a/src/main/www/src/components/Application/Application.js
+++ b/src/main/www/src/components/Application/Application.js
@@ -299,6 +299,7 @@ export default function Application() {
             resetMembershipLevelForm={formikMembershipLevel.resetForm}
             resetWorkingGroupForm={formikWorkingGroups.resetForm}
             resetSigningAuthorityForm={formikSigningAuthority.resetForm}
+            setUpdatedFormValues={setUpdatedFormValues}
           />
         </Route>
 

--- a/src/main/www/src/components/Application/SignIn/SignIn.js
+++ b/src/main/www/src/components/Application/SignIn/SignIn.js
@@ -132,6 +132,7 @@ class SignIn extends React.Component {
             resetMembershipLevelForm={this.props.resetMembershipLevelForm}
             resetWorkingGroupForm={this.props.resetWorkingGroupForm}
             resetSigningAuthorityForm={this.props.resetSigningAuthorityForm}
+            setUpdatedFormValues={this.props.setUpdatedFormValues}
           />
         ) : (
           this.renderButtons(this.props.setFurthestPage)

--- a/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
+++ b/src/main/www/src/components/UIComponents/FormPreprocess/FormChooser.js
@@ -13,6 +13,7 @@ import {
 } from '../../../Utils/formFunctionHelpers';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import Loading from '../Loading/Loading';
+import { initialValues } from '../FormComponents/formFieldModel';
 const styles = {
   marginBottom: '30px',
   textAlign: 'center',
@@ -26,6 +27,7 @@ const FormChooser = ({
   resetWorkingGroupForm,
   resetMembershipLevelForm,
   resetCompanyInfoForm,
+  setUpdatedFormValues
 }) => {
   const { setCurrentFormId, furthestPage } = useContext(MembershipContext);
   const [hasExistingForm, setHasExistingForm] = useState('');
@@ -42,7 +44,10 @@ const FormChooser = ({
 
   const handleStartNewForm = () => {
     setIsStartNewForm(true);
-    if (getCurrentMode() === MODE_REACT_API) setCurrentFormId('');
+    setUpdatedFormValues(initialValues); // reset backup values
+    if (getCurrentMode() === MODE_REACT_API) {
+      setCurrentFormId('');
+    }
     // reset the form if user has gone to a further page/step
     if (furthestPage.index > 0) {
       resetCompanyInfoForm();


### PR DESCRIPTION
For this task flow:

1. User selects "Continue Existing Form" (the existing one must have company info step filled)
2. In company info step, goes back to sign in step with invalid values in some fields (chooses "Leave")
3.  Chooses "Start New Application"
4. In company info step, goes back to sign in step with invalid values in some fields (chooses "Leave")
5. Chooses "Continue Existing Form"

In step 5, user should see an empty form as the values should be reset to empty in step 4. 
But without the fix, user will see the values in step 1, as we don't reset the backup values when user chooses "Start New Application". So, in step 4, the values for reset are the ones in step 1.