### PR TITLE
Add additional check to ensure the dateUpdated is present when checking

### DIFF
--- a/src/main/java/org/eclipsefoundation/react/dto/MembershipForm.java
+++ b/src/main/java/org/eclipsefoundation/react/dto/MembershipForm.java
@@ -276,6 +276,8 @@ public class MembershipForm extends BareNode implements TargetedClone<Membership
             if (dateCreated != null && StringUtils.isNumeric(dateCreated)) {
                 stmt.addClause(new ParameterizedSQLStatement.Clause(TABLE.getAlias() + ".dateUpdated < ?",
                         new Object[] { Long.parseLong(dateCreated) }));
+                stmt.addClause(new ParameterizedSQLStatement.Clause(TABLE.getAlias() + ".dateUpdated IS NOT NULL",
+                        new Object[] {}));
             }
             return stmt;
         }


### PR DESCRIPTION
Line adds another SQL clause saying that the dateUpdated is not null when comparing date. This should be what happens already but this is extra insurance